### PR TITLE
Fix "ghost" artifacts for embedded windows on macOS

### DIFF
--- a/generic/tkpCanvas.c
+++ b/generic/tkpCanvas.c
@@ -322,7 +322,6 @@ static Tk_ClassProcs canvasClass = {
     PathCanvasWorldChanged,	/* worldChangedProc */
 };
 
-
 /*
  * Macros that significantly simplify all code that finds items.
  */

--- a/generic/tkpCanvas.c
+++ b/generic/tkpCanvas.c
@@ -322,6 +322,7 @@ static Tk_ClassProcs canvasClass = {
     PathCanvasWorldChanged,	/* worldChangedProc */
 };
 
+
 /*
  * Macros that significantly simplify all code that finds items.
  */
@@ -3271,6 +3272,17 @@ DisplayCanvas(
 	Tk_ClipDrawableToRect(Tk_Display(tkwin), pixmap,
 		screenX1 - canvasPtr->xOrigin, screenY1 - canvasPtr->yOrigin,
 		width, height);
+	/*
+	 * Force an update of the clipping regions for all embedded windows,
+	 * to prevent "ghosts".
+	 */
+	for (itemPtr = canvasPtr->rootItemPtr; itemPtr != NULL;
+	    itemPtr = TkPathCanvasItemIteratorNext(itemPtr)) {
+	    if (strncmp(itemPtr->typePtr->name, "window", 6) == 0) {
+		itemPtr->typePtr->displayProc((Tk_PathCanvas)canvasPtr, itemPtr,
+		    canvasPtr->display, pixmap, screenX1, screenY1, width, height);
+	    }
+	}
 #else
 	TkpClipDrawableToRect(Tk_Display(tkwin), pixmap,
 		screenX1 - canvasPtr->xOrigin, screenY1 - canvasPtr->yOrigin,


### PR DESCRIPTION
This is a backport of a similar fix to tkCanvas.c used in Tk 9.0.2 and 9.1.  It fixes issue #6.

On macOS, every Tk Window maintains a clipping region which excludes all children of the window. If those clipping regions do not match the actual locations of the child windows then "ghost window" artifacts appear because the background fill does not cover the bounding rectangle of the child windows.  This fix forces an update of the clipping region maintained by the tkpath canvas by calling the display proc of each embedded window.